### PR TITLE
bug: fix to use user defined default sampling rule for X-Ray

### DIFF
--- a/source/extensions/tracers/xray/localized_sampling.cc
+++ b/source/extensions/tracers/xray/localized_sampling.cc
@@ -177,16 +177,16 @@ LocalizedSamplingManifest::LocalizedSamplingManifest(const std::string& rule_jso
 }
 
 bool LocalizedSamplingStrategy::shouldTrace(const SamplingRequest& sampling_request) {
-  if (!custom_manifest_.hasCustomRules()) {
-    return shouldTrace(default_manifest_.defaultRule());
+  if (!manifest_.hasCustomRules()) {
+    return shouldTrace(manifest_.defaultRule());
   }
 
-  for (auto&& rule : custom_manifest_.customRules()) {
+  for (auto&& rule : manifest_.customRules()) {
     if (rule.appliesTo(sampling_request)) {
       return shouldTrace(rule);
     }
   }
-  return shouldTrace(custom_manifest_.defaultRule());
+  return shouldTrace(manifest_.defaultRule());
 }
 
 bool LocalizedSamplingStrategy::shouldTrace(LocalizedSamplingRule& rule) {

--- a/source/extensions/tracers/xray/localized_sampling.h
+++ b/source/extensions/tracers/xray/localized_sampling.h
@@ -138,33 +138,21 @@ class LocalizedSamplingStrategy : public SamplingStrategy {
 public:
   LocalizedSamplingStrategy(const std::string& sampling_rules_json, Random::RandomGenerator& rng,
                             TimeSource& time_source)
-      : SamplingStrategy(rng), default_manifest_(LocalizedSamplingManifest::createDefault()),
-        custom_manifest_(sampling_rules_json), time_source_(time_source),
-        use_default_(!custom_manifest_.hasCustomRules()) {}
+      : SamplingStrategy(rng), manifest_(sampling_rules_json), time_source_(time_source) {}
 
   /**
-   * Determines if an incoming request matches one of the sampling rules in the local manifests.
+   * Determines if an incoming request matches one of the sampling rules in the local manifest.
    * If a match is found, then the request might be traced based on the sampling percentages etc.
    * determined by the matching rule.
    */
   bool shouldTrace(const SamplingRequest& sampling_request) override;
 
-  /**
-   * Determines whether default rules are in effect. Mainly for unit testing purposes.
-   */
-  bool usingDefaultManifest() const { return use_default_; }
-
-  /**
-   * @return the default manifest. Mainly for unit testing purposes.
-   */
-  const LocalizedSamplingManifest& defaultManifest() const { return default_manifest_; }
+  const LocalizedSamplingManifest manifest() const { return manifest_; }
 
 private:
   bool shouldTrace(LocalizedSamplingRule& rule);
-  LocalizedSamplingManifest default_manifest_;
-  LocalizedSamplingManifest custom_manifest_;
+  LocalizedSamplingManifest manifest_;
   TimeSource& time_source_;
-  bool use_default_;
 };
 
 } // namespace XRay

--- a/test/extensions/tracers/xray/localized_sampling_test.cc
+++ b/test/extensions/tracers/xray/localized_sampling_test.cc
@@ -24,24 +24,43 @@ protected:
 TEST_F(LocalizedSamplingStrategyTest, EmptyRules) {
   NiceMock<Random::MockRandomGenerator> random_generator;
   LocalizedSamplingStrategy strategy{"", random_generator, time_system_};
-  ASSERT_TRUE(strategy.usingDefaultManifest());
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
 }
 
 TEST_F(LocalizedSamplingStrategyTest, BadJson) {
   NiceMock<Random::MockRandomGenerator> random_generator;
   LocalizedSamplingStrategy strategy{"{{}", random_generator, time_system_};
-  ASSERT_TRUE(strategy.usingDefaultManifest());
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
 }
 
 TEST_F(LocalizedSamplingStrategyTest, EmptyRulesDefaultRate) {
   NiceMock<Random::MockRandomGenerator> random_generator;
   LocalizedSamplingStrategy strategy{"{{}", random_generator, time_system_};
-  ASSERT_TRUE(strategy.usingDefaultManifest());
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
   // Make a copy of default_manifest_(LocalizedSamplingManifest object) since the
   // object returned is a const reference and defaultRule() function is not a
   // 'const member function' of LocalizedSamplingManifest class.
-  LocalizedSamplingManifest default_manifest_copy{strategy.defaultManifest()};
-  ASSERT_EQ(default_manifest_copy.defaultRule().rate(), 0.05);
+  LocalizedSamplingManifest manifest_copy{strategy.manifest()};
+  // default sampling rate of 0.05
+  ASSERT_EQ(manifest_copy.defaultRule().rate(), 0.05);
+}
+
+TEST_F(LocalizedSamplingStrategyTest, MissingRulesUseCustomDefault) {
+  NiceMock<Random::MockRandomGenerator> random_generator;
+  constexpr auto rules_json = R"EOF(
+{
+    "version": 2,
+    "rules": [],
+    "default": {
+        "fixed_target": 1,
+        "rate": 0.1
+    }
+}
+    )EOF";
+  LocalizedSamplingStrategy strategy{rules_json, random_generator, time_system_};
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
+  LocalizedSamplingManifest manifest_copy{strategy.manifest()};
+  ASSERT_EQ(manifest_copy.defaultRule().rate(), 0.1);
 }
 
 TEST_F(LocalizedSamplingStrategyTest, ValidCustomRules) {
@@ -66,10 +85,40 @@ TEST_F(LocalizedSamplingStrategyTest, ValidCustomRules) {
 }
   )EOF";
   LocalizedSamplingStrategy strategy{rules_json, random_generator, time_system_};
-  ASSERT_FALSE(strategy.usingDefaultManifest());
+  ASSERT_TRUE(strategy.manifest().hasCustomRules());
+  LocalizedSamplingManifest manifest_copy{strategy.manifest()};
+  ASSERT_EQ(manifest_copy.defaultRule().rate(), 0.1);
 }
 
-TEST_F(LocalizedSamplingStrategyTest, InvalidRate) {
+TEST_F(LocalizedSamplingStrategyTest, InvalidDefaultRuleRate) {
+  NiceMock<Random::MockRandomGenerator> random_generator;
+  constexpr auto rules_json = R"EOF(
+{
+  "version": 2,
+  "rules": [
+    {
+      "description": "X-Ray rule",
+      "host": "*",
+      "http_method": "*",
+      "url_path": "/api/move/*",
+      "fixed_target": 0,
+      "rate": 0.5
+    }
+  ],
+  "default": {
+    "fixed_target": 1,
+    "rate": 1.5
+  }
+}
+  )EOF";
+  LocalizedSamplingStrategy strategy{rules_json, random_generator, time_system_};
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
+  LocalizedSamplingManifest manifest_copy{strategy.manifest()};
+  // default sampling rate of 0.05
+  ASSERT_EQ(manifest_copy.defaultRule().rate(), 0.05);
+}
+
+TEST_F(LocalizedSamplingStrategyTest, InvalidRulesRate) {
   NiceMock<Random::MockRandomGenerator> random_generator;
   constexpr auto rules_json = R"EOF(
 {
@@ -91,7 +140,9 @@ TEST_F(LocalizedSamplingStrategyTest, InvalidRate) {
 }
   )EOF";
   LocalizedSamplingStrategy strategy{rules_json, random_generator, time_system_};
-  ASSERT_TRUE(strategy.usingDefaultManifest());
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
+  LocalizedSamplingManifest manifest_copy{strategy.manifest()};
+  ASSERT_EQ(manifest_copy.defaultRule().rate(), 0);
 }
 
 TEST_F(LocalizedSamplingStrategyTest, InvalidFixedTarget) {
@@ -116,7 +167,7 @@ TEST_F(LocalizedSamplingStrategyTest, InvalidFixedTarget) {
 }
   )EOF";
   LocalizedSamplingStrategy strategy{rules_json, random_generator, time_system_};
-  ASSERT_TRUE(strategy.usingDefaultManifest());
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
 }
 
 TEST_F(LocalizedSamplingStrategyTest, DefaultRuleMissingRate) {
@@ -140,7 +191,10 @@ TEST_F(LocalizedSamplingStrategyTest, DefaultRuleMissingRate) {
 }
   )EOF";
   LocalizedSamplingStrategy strategy{rules_json, random_generator, time_system_};
-  ASSERT_TRUE(strategy.usingDefaultManifest());
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
+  LocalizedSamplingManifest manifest_copy{strategy.manifest()};
+  // default sampling rate of 0.05
+  ASSERT_EQ(manifest_copy.defaultRule().rate(), 0.05);
 }
 
 TEST_F(LocalizedSamplingStrategyTest, DefaultRuleMissingFixedTarget) {
@@ -164,7 +218,10 @@ TEST_F(LocalizedSamplingStrategyTest, DefaultRuleMissingFixedTarget) {
 }
   )EOF";
   LocalizedSamplingStrategy strategy{rules_json, random_generator, time_system_};
-  ASSERT_TRUE(strategy.usingDefaultManifest());
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
+  LocalizedSamplingManifest manifest_copy{strategy.manifest()};
+  // default sampling rate of 0.05
+  ASSERT_EQ(manifest_copy.defaultRule().rate(), 0.05);
 }
 
 TEST_F(LocalizedSamplingStrategyTest, WrongVersion) {
@@ -189,7 +246,10 @@ TEST_F(LocalizedSamplingStrategyTest, WrongVersion) {
 }
   )EOF";
   LocalizedSamplingStrategy strategy{wrong_version, random_generator, time_system_};
-  ASSERT_TRUE(strategy.usingDefaultManifest());
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
+  LocalizedSamplingManifest manifest_copy{strategy.manifest()};
+  // default sampling rate of 0.05
+  ASSERT_EQ(manifest_copy.defaultRule().rate(), 0.05);
 }
 
 TEST_F(LocalizedSamplingStrategyTest, MissingVersion) {
@@ -213,7 +273,10 @@ TEST_F(LocalizedSamplingStrategyTest, MissingVersion) {
 }
   )EOF";
   LocalizedSamplingStrategy strategy{missing_version, random_generator, time_system_};
-  ASSERT_TRUE(strategy.usingDefaultManifest());
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
+  LocalizedSamplingManifest manifest_copy{strategy.manifest()};
+  // default sampling rate of 0.05
+  ASSERT_EQ(manifest_copy.defaultRule().rate(), 0.05);
 }
 
 TEST_F(LocalizedSamplingStrategyTest, MissingDefaultRules) {
@@ -234,7 +297,10 @@ TEST_F(LocalizedSamplingStrategyTest, MissingDefaultRules) {
 }
   )EOF";
   LocalizedSamplingStrategy strategy{rules_json, random_generator, time_system_};
-  ASSERT_TRUE(strategy.usingDefaultManifest());
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
+  LocalizedSamplingManifest manifest_copy{strategy.manifest()};
+  // default sampling rate of 0.05
+  ASSERT_EQ(manifest_copy.defaultRule().rate(), 0.05);
 }
 
 TEST_F(LocalizedSamplingStrategyTest, CustomRuleHostIsNotString) {
@@ -259,7 +325,9 @@ TEST_F(LocalizedSamplingStrategyTest, CustomRuleHostIsNotString) {
 }
   )EOF";
   LocalizedSamplingStrategy strategy{rules_json, random_generator, time_system_};
-  ASSERT_TRUE(strategy.usingDefaultManifest());
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
+  LocalizedSamplingManifest manifest_copy{strategy.manifest()};
+  ASSERT_EQ(manifest_copy.defaultRule().rate(), 0.1);
 }
 
 TEST_F(LocalizedSamplingStrategyTest, CustomRuleHttpMethodIsNotString) {
@@ -284,7 +352,9 @@ TEST_F(LocalizedSamplingStrategyTest, CustomRuleHttpMethodIsNotString) {
 }
   )EOF";
   LocalizedSamplingStrategy strategy{rules_json, random_generator, time_system_};
-  ASSERT_TRUE(strategy.usingDefaultManifest());
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
+  LocalizedSamplingManifest manifest_copy{strategy.manifest()};
+  ASSERT_EQ(manifest_copy.defaultRule().rate(), 0.1);
 }
 
 TEST_F(LocalizedSamplingStrategyTest, CustomRuleUrlPathIsNotString) {
@@ -309,7 +379,10 @@ TEST_F(LocalizedSamplingStrategyTest, CustomRuleUrlPathIsNotString) {
 }
   )EOF";
   LocalizedSamplingStrategy strategy{rules_json, random_generator, time_system_};
-  ASSERT_TRUE(strategy.usingDefaultManifest());
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
+  LocalizedSamplingManifest manifest_copy{strategy.manifest()};
+  // custom default rate
+  ASSERT_EQ(manifest_copy.defaultRule().rate(), 0.1);
 }
 
 TEST_F(LocalizedSamplingStrategyTest, CustomRuleMissingFixedTarget) {
@@ -333,7 +406,10 @@ TEST_F(LocalizedSamplingStrategyTest, CustomRuleMissingFixedTarget) {
 }
   )EOF";
   LocalizedSamplingStrategy strategy{rules_json, random_generator, time_system_};
-  ASSERT_TRUE(strategy.usingDefaultManifest());
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
+  LocalizedSamplingManifest manifest_copy{strategy.manifest()};
+  // custom default rate
+  ASSERT_EQ(manifest_copy.defaultRule().rate(), 0.1);
 }
 
 TEST_F(LocalizedSamplingStrategyTest, CustomRuleMissingRate) {
@@ -357,7 +433,10 @@ TEST_F(LocalizedSamplingStrategyTest, CustomRuleMissingRate) {
 }
   )EOF";
   LocalizedSamplingStrategy strategy{rules_json, random_generator, time_system_};
-  ASSERT_TRUE(strategy.usingDefaultManifest());
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
+  LocalizedSamplingManifest manifest_copy{strategy.manifest()};
+  // custom default rate
+  ASSERT_EQ(manifest_copy.defaultRule().rate(), 0.1);
 }
 
 TEST_F(LocalizedSamplingStrategyTest, CustomRuleArrayElementWithWrongType) {
@@ -382,10 +461,13 @@ TEST_F(LocalizedSamplingStrategyTest, CustomRuleArrayElementWithWrongType) {
 }
   )EOF";
   LocalizedSamplingStrategy strategy{rules_json, random_generator, time_system_};
-  ASSERT_TRUE(strategy.usingDefaultManifest());
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
+  LocalizedSamplingManifest manifest_copy{strategy.manifest()};
+  // custom default rate
+  ASSERT_EQ(manifest_copy.defaultRule().rate(), 0.1);
 }
 
-TEST_F(LocalizedSamplingStrategyTest, CustomRuleNegativeFixedRate) {
+TEST_F(LocalizedSamplingStrategyTest, CustomRuleNegativeFixedTarget) {
   NiceMock<Random::MockRandomGenerator> random_generator;
   constexpr auto rules_json = R"EOF(
 {
@@ -407,7 +489,10 @@ TEST_F(LocalizedSamplingStrategyTest, CustomRuleNegativeFixedRate) {
 }
   )EOF";
   LocalizedSamplingStrategy strategy{rules_json, random_generator, time_system_};
-  ASSERT_TRUE(strategy.usingDefaultManifest());
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
+  LocalizedSamplingManifest manifest_copy{strategy.manifest()};
+  // custom default rate
+  ASSERT_EQ(manifest_copy.defaultRule().rate(), 0.1);
 }
 
 TEST_F(LocalizedSamplingStrategyTest, CustomRuleNegativeRate) {
@@ -422,17 +507,20 @@ TEST_F(LocalizedSamplingStrategyTest, CustomRuleNegativeRate) {
       "http_method": "*",
       "url_path": "/api/move/*",
       "fixed_target": 0,
-      "rate": 0.05
+      "rate": -0.05
     }
   ],
   "default": {
     "fixed_target": 1,
-    "rate": -0.1
+    "rate": 0.1
   }
 }
   )EOF";
   LocalizedSamplingStrategy strategy{rules_json, random_generator, time_system_};
-  ASSERT_TRUE(strategy.usingDefaultManifest());
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
+  LocalizedSamplingManifest manifest_copy{strategy.manifest()};
+  // custom default rate
+  ASSERT_EQ(manifest_copy.defaultRule().rate(), 0.1);
 }
 
 TEST_F(LocalizedSamplingStrategyTest, TraceOnlyFromReservoir) {
@@ -459,12 +547,11 @@ TEST_F(LocalizedSamplingStrategyTest, TraceOnlyFromReservoir) {
   )EOF";
 
   LocalizedSamplingStrategy strategy{rules_json, rng, time_system_};
-  ASSERT_FALSE(strategy.usingDefaultManifest());
+  ASSERT_TRUE(strategy.manifest().hasCustomRules());
 
   SamplingRequest req;
   ASSERT_TRUE(strategy.shouldTrace(req)); // first one should be traced
-  int i = 10;
-  while (i-- > 0) {
+  for (int i = 0; i < 10; ++i) {
     ASSERT_FALSE(strategy.shouldTrace(req));
   }
 }
@@ -493,11 +580,10 @@ TEST_F(LocalizedSamplingStrategyTest, TraceFromReservoirAndByRate) {
   )EOF";
 
   LocalizedSamplingStrategy strategy{rules_json, rng, time_system_};
-  ASSERT_FALSE(strategy.usingDefaultManifest());
+  ASSERT_TRUE(strategy.manifest().hasCustomRules());
 
   SamplingRequest req;
-  int i = 10;
-  while (i-- > 0) {
+  for (int i = 0; i < 10; ++i) {
     ASSERT_TRUE(strategy.shouldTrace(req));
   }
 }
@@ -530,12 +616,12 @@ TEST_F(LocalizedSamplingStrategyTest, NoMatchingHost) {
   )EOF";
 
   LocalizedSamplingStrategy strategy{rules_json, rng, time_system_};
-  ASSERT_FALSE(strategy.usingDefaultManifest());
+  ASSERT_TRUE(strategy.manifest().hasCustomRules());
 
   SamplingRequest req;
   req.host_ = "amazon.com"; // host does not match, so default rules apply.
   int i = 10;
-  while (i-- > 0) {
+  for (int i = 0; i < 10; ++i) {
     ASSERT_FALSE(strategy.shouldTrace(req));
   }
 }
@@ -568,12 +654,11 @@ TEST_F(LocalizedSamplingStrategyTest, NoMatchingHttpMethod) {
   )EOF";
 
   LocalizedSamplingStrategy strategy{rules_json, rng, time_system_};
-  ASSERT_FALSE(strategy.usingDefaultManifest());
+  ASSERT_TRUE(strategy.manifest().hasCustomRules());
 
   SamplingRequest req;
   req.http_method_ = "GET"; // method does not match, so default rules apply.
-  int i = 10;
-  while (i-- > 0) {
+  for (int i = 0; i < 10; ++i) {
     ASSERT_FALSE(strategy.shouldTrace(req));
   }
 }
@@ -606,12 +691,61 @@ TEST_F(LocalizedSamplingStrategyTest, NoMatchingPath) {
   )EOF";
 
   LocalizedSamplingStrategy strategy{rules_json, rng, time_system_};
-  ASSERT_FALSE(strategy.usingDefaultManifest());
+  ASSERT_TRUE(strategy.manifest().hasCustomRules());
 
   SamplingRequest req;
   req.http_url_ = "/"; // method does not match, so default rules apply.
-  int i = 10;
-  while (i-- > 0) {
+  for (int i = 0; i < 10; ++i) {
+    ASSERT_FALSE(strategy.shouldTrace(req));
+  }
+}
+
+TEST_F(LocalizedSamplingStrategyTest, CustomDefaultRule) {
+  NiceMock<Random::MockRandomGenerator> rng;
+  // this following value doesn't affect the test
+  EXPECT_CALL(rng, random()).WillRepeatedly(Return(50 /*50 percent*/));
+
+  constexpr auto rules_json = R"EOF(
+{
+  "version": 2,
+  "default": {
+    "fixed_target": 0,
+    "rate": 0
+  }
+}
+  )EOF";
+
+  LocalizedSamplingStrategy strategy{rules_json, rng, time_system_};
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
+
+  SamplingRequest req;
+  req.http_url_ = "/";
+  for (int i = 0; i < 10; ++i) {
+    ASSERT_FALSE(strategy.shouldTrace(req));
+  }
+}
+
+TEST_F(LocalizedSamplingStrategyTest, InvalidCustomDefaultRule) {
+  NiceMock<Random::MockRandomGenerator> rng;
+  // this following value doesn't affect the test
+  EXPECT_CALL(rng, random()).WillRepeatedly(Return(50 /*50 percent*/));
+  constexpr auto rules_json = R"EOF(
+{
+"version": 2,
+"default": {
+  "fixed_target": 0,
+  "rate": 2.0
+  }
+}
+)EOF";
+
+  LocalizedSamplingStrategy strategy{rules_json, rng, time_system_};
+  ASSERT_FALSE(strategy.manifest().hasCustomRules());
+
+  SamplingRequest req;
+  req.http_url_ = "/";
+  ASSERT_TRUE(strategy.shouldTrace(req)); // The default rule traces the first request each second
+  for (int i = 0; i < 10; ++i) {
     ASSERT_FALSE(strategy.shouldTrace(req));
   }
 }


### PR DESCRIPTION
Signed-off-by: Shweta Sahu <sshwat@amazon.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: bug: fix to use user defined default sampling rule for x-ray
Additional Description: If a user provides a custom manifest with a newly-defined, valid default rule, and no custom rules, Envoy ignores the user's modified default rule and uses the built-in default rule instead. With this fix, envoy will use user defined default rule.

Risk Level: Low
Testing: unit test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #18283]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional API Considerations:]


